### PR TITLE
TRIVIAL: Minor fixes to init script handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,3 +39,7 @@ v2.0 lorenzb,els0r
     - query all interfaces for which there is data by specifying '-i ANY'
     - add unit and system (i.e. output consistency) tests
     - extensive bash completion with support for condition grammar, interface names, query types, ...
+
+v2.01 fako1024
+    - Fix stale socket file after non-graceful stop of goprobe
+    - Rename "status" target to "info" to avoid overlap with systemd status target

--- a/addon/goprobe.init
+++ b/addon/goprobe.init
@@ -40,8 +40,8 @@ DAEMON_CONF=$PREFIX/goProbe/etc/goprobe.conf
 DAEMON_ARGS="-config $DAEMON_CONF"
 SCRIPTNAME=/etc/init.d/goprobe.init
 
-# DB Path is set by the config (the default path may not exist)
-DB_PATH=$PREFIX/goProbe/db
+# DB Path is extracted from the configuration file
+DB_PATH=$( grep db_path $DAEMON_CONF | cut -d ':' -f 2 | sed 's/[",]//g' )
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -86,6 +86,10 @@ do_start()
     #   2 if daemon could not be started
     start-stop-daemon --start --background --make-pidfile --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
         || return 1
+
+    # Remove stale control socket if it exists
+    [ -e $DB_PATH/control.sock ] && rm -f $DB_PATH/control.sock
+
     start-stop-daemon --start --background --make-pidfile --quiet --pidfile $PIDFILE --exec $DAEMON -- \
         $DAEMON_ARGS \
         || return 2
@@ -138,7 +142,7 @@ case "$1" in
         2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
     esac
     ;;
-  status)
+  info)
     retval=0
     echo -n "Checking for running daemon ............... "
     pid=`pgrep -f "$DAEMON $DAEMON_ARGS"`


### PR DESCRIPTION
- Fix stale socket file after non-graceful stop of goprobe (force remove on start if not yet running)
- Rename "status" target to "info" to avoid overlap with systemd status target
- Extract DB path in init script from config file (fixes cases where the DB is kept in a different place than the binaries (i.e. $PREFIX/goProbe/db does not contain the DB)
